### PR TITLE
Update pubspec.yaml to support Null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^0.5.8
+  shared_preferences: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
updated shared preferences package to:

shared_preferences: ^2.0.3

This enables flutter_session to be used with other null safe packages.